### PR TITLE
Support the "Died" and "Interdicted" events

### DIFF
--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -40,7 +40,7 @@
                     "format"        : "date-time"
                 },
                 "event" : {
-                    "enum"          : [ "Docked", "FSDJump", "Scan", "Location" ]
+                    "enum"          : [ "Docked", "FSDJump", "Scan", "Location", "Died", "Interdicted" ]
                 },
                 "StarSystem": {
                     "type"          : "string",
@@ -61,7 +61,17 @@
                 "FuelUsed"          : { "$ref" : "#/definitions/disallowed" },
                 "JumpDist"          : { "$ref" : "#/definitions/disallowed" },
                 "Latitude"          : { "$ref" : "#/definitions/disallowed" },
-                "Longitude"         : { "$ref" : "#/definitions/disallowed" }
+                "Longitude"         : { "$ref" : "#/definitions/disallowed" },
+                "KillerName"        : { "$ref" : "#/definitions/disallowed" },
+                "KillerShip"        : { "$ref" : "#/definitions/disallowed" },
+                "KillerRank"        : { "$ref" : "#/definitions/disallowed" },
+                "Killers"           : { "$ref" : "#/definitions/disallowed" },
+                "Submitted"         : { "$ref" : "#/definitions/disallowed" },
+                "Interdictor"       : { "$ref" : "#/definitions/disallowed" },
+                "CombatRank"        : { "$ref" : "#/definitions/disallowed" },
+                "Faction"           : { "$ref" : "#/definitions/disallowed" },
+                "Power"             : { "$ref" : "#/definitions/disallowed" },
+                "IsPlayer"          : { "$ref" : "#/definitions/disallowed" }
             },
             "patternProperties"     : {
                 "_Localised$"       : { "$ref" : "#/definitions/disallowed" }

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     long_description="""\
       The Elite: Dangerous Data Network allows E:D players to share data. Not affiliated with Frontier Developments.
       """,
-    install_requires=["argparse", "bottle", "enum34", "gevent", "jsonschema", "pyzmq", "simplejson"],
+    install_requires=["argparse", "bottle", "enum34", "gevent", "jsonschema", "pyzmq", "simplejson", "strict-rfc3339"],
     entry_points={
         'console_scripts': [
             'eddn-gateway = eddn.Gateway:main',


### PR DESCRIPTION
Disallow all data for Died and Interdicted (we just want the star system and timestamp)

Also add strict-rfc3339 to setup.py