### PR TITLE
Re #77 Added [header][uploaderPrivacy] which can be "random" or "clear"

### DIFF
--- a/schemas/blackmarket-v1.0.json
+++ b/schemas/blackmarket-v1.0.json
@@ -16,6 +16,9 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "uploaderPrivacy" : {
+                    "enum"          : [ "random", "clear" ]
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/commodity-v3.0.json
+++ b/schemas/commodity-v3.0.json
@@ -16,6 +16,9 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "uploaderPrivacy" : {
+                    "enum"          : [ "random", "clear" ]
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -16,6 +16,9 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "uploaderPrivacy" : {
+                    "enum"          : [ "random", "clear" ]
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/outfitting-v2.0.json
+++ b/schemas/outfitting-v2.0.json
@@ -16,6 +16,9 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "uploaderPrivacy" : {
+                    "enum"          : [ "random", "clear" ]
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/shipyard-v2.0.json
+++ b/schemas/shipyard-v2.0.json
@@ -16,6 +16,9 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "uploaderPrivacy" : {
+                    "enum"          : [ "random", "clear" ]
+                },
                 "softwareName": {
                     "type"          : "string"
                 },


### PR DESCRIPTION
Omitting the value or submitting an unknown one will default to "random"

The following values are permitted

"random":
  The standard behaviour of masking the uploaderID will be used

"clear":
  The original uploaderID value will not be modified or deleted

This would of course only be useful if EDSM or EDMC implement this