### PR TITLE
monitor: Fix typo of schemasTodayYesterday with its 's' on 'schemas'

### DIFF
--- a/contrib/monitor/js/eddn.js
+++ b/contrib/monitor/js/eddn.js
@@ -528,7 +528,7 @@ var doUpdateSchemas = function()
         success: function(schemasTodayYesterday){
             // Might happen when nothing is received...
             if(schemasTodayYesterday[yesterday] == undefined)
-                schemaTodayYesterday[yesterday] = [];
+                schemasTodayYesterday[yesterday] = [];
             if(schemasTodayYesterday[today] == undefined)
                 schemasTodayYesterday[today] = [];
 


### PR DESCRIPTION
A very simple fix for an issue that only shows up when testing, i.e. no 'yesterday' data.