### PR TITLE
schemas/codexentry: Add BodyID/Name, and -README file

### DIFF
--- a/schemas/codexentry-README.md
+++ b/schemas/codexentry-README.md
@@ -1,0 +1,49 @@
+# EDDN CodexEntry Schema
+
+## Introduction
+Here we document how to take data from an ED `CodexEntry` Journal Event and
+properly structure it for sending to EDDN.
+
+Please see [EDDN Schemas](...) for general documentation for a schema such as
+this.
+
+## Senders
+The primary data source for this schema is the ED Journal event `CodexEntry`.
+
+### Elisions
+You MUST remove any key where the key name ends in 
+`_Localised`.
+
+You MUST remove the two keys `IsNewEntry` and `NewTraitsDiscovered`.
+
+### Augmentations
+#### StarPos
+You MUST **add** a `StarPos` key with value of type `array` containing the 
+galaxy co-ordinates of the system.  You will need to have obtained these 
+from prior event(s) upon the player arriving, or logging into, the system.
+
+e.g. if the system is `Alpha Centauri`:
+```json
+    "StarPos": [3.03125, -0.09375, 3.15625]
+```
+
+#### BodyID and BodyName
+You SHOULD attempt to track the BodyName and BodyID where the player is 
+and add keys/values for these.
+
+For `BodyName` you MUST retrieve this from the latest `Status.json` data, 
+using the `Body` value there-in.
+
+You can obtain the `BodyID` from a `ApproachBody` or `Location` event.  
+You MUST cross-check the `Body` value in this to ensure it has the same 
+name as you got from `Status.json`.  One possible issue is binary bodies where
+you might get an `ApproachBody` for one before descending towards the other, 
+without an additional `ApproachBody` to correct things.
+
+e.g. for `Bestia A 2 a`
+```json
+    "BodyName": "Bestia A 2 a",
+    "BodyID": 15,
+```
+
+## Receivers

--- a/schemas/codexentry-v1.0.json
+++ b/schemas/codexentry-v1.0.json
@@ -1,6 +1,7 @@
 {
     "$schema"               : "http://json-schema.org/draft-04/schema#",
     "id"                    : "https://eddn.edcd.io/schemas/codexentry/1#",
+    "description"           : "EDDN schema for CodexEntry Journal events.  Full documentation at https://github.com/EDCD/EDDN/tree/master/schemas/codexentry-README.md",
     "type"                  : "object",
     "additionalProperties"  : false,
     "required": [ "$schemaRef", "header", "message" ],
@@ -103,6 +104,12 @@
                         "type"          : "string",
                         "minLength"     : 1
                     }
+                },
+                "BodyID": {
+                    "type"          : "integer"
+                },
+                "BodyName": {
+                    "type"          : "string",
                 },
                 "IsNewEntry": {
                     "$ref"          : "#/definitions/disallowed",


### PR DESCRIPTION
Add BodyID and BodyName to the codexentry schema *and* document how to properly set up data to send on this schema in separate README file.

Closes #145 