### PR TITLE
schemas: codexentry needs to allow empty NearestDestination

### DIFF
--- a/schemas/codexentry-v1.0.json
+++ b/schemas/codexentry-v1.0.json
@@ -92,8 +92,7 @@
                     "minLength"     : 1
                 },
                 "NearestDestination": {
-                    "type"          : "string",
-                    "minLength"     : 1
+                    "type"          : "string"
                 },
                 "VoucherAmount": {
                     "type"          : "integer"


### PR DESCRIPTION
It's perfectly valid, as shown by an old event from my own journals below:

```json
{
  "timestamp":"2021-06-02T10:48:53Z",
  "event":"CodexEntry",
  "EntryID":2420201,
  "Name":"$Codex_Ent_Stratum_02_F_Name;",
  "Name_Localised":"Stratum Paleas - Emerald",
  "SubCategory":"$Codex_SubCategory_Organic_Structures;",
  "SubCategory_Localised":"Organic structures",
  "Category":"$Codex_Category_Biology;",
  "Category_Localised":"Biological and Geological",
  "Region":"$Codex_RegionName_18;",
  "Region_Localised":"Inner Orion Spur",
  "System":"HIP 36014",
  "SystemAddress":1659744831835,
  "NearestDestination":"",
  "Latitude":59.322433,
  "Longitude":-131.345062,
  "IsNewEntry":true }
```