### PR TITLE
Address `bottle` default request size rejecting some messages

### DIFF
--- a/src/eddn/Gateway.py
+++ b/src/eddn/Gateway.py
@@ -21,7 +21,9 @@ from eddn.core.Validator import Validator, ValidationSeverity
 
 from gevent import monkey
 monkey.patch_all()
+import bottle
 from bottle import Bottle, run, request, response, get, post
+bottle.BaseRequest.MEMFILE_MAX = 1024 * 1024 # 1MiB, default is/was 100KiB
 app = Bottle()
 
 logger = logging.getLogger(__name__)

--- a/src/eddn/Gateway.py
+++ b/src/eddn/Gateway.py
@@ -28,7 +28,14 @@ app = Bottle()
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler())
+__logger_channel = logging.StreamHandler()
+__logger_formatter = logging.Formatter(
+    '%(asctime)s - %(levelname)s - %(module)s:%(lineno)d: %(message)s'
+)
+__logger_formatter.default_time_format = '%Y-%m-%d %H:%M:%S'
+__logger_formatter.default_msec_format = '%s.%03d'
+__logger_channel.setFormatter(__logger_formatter)
+logger.addHandler(__logger_channel)
 logger.info('Made logger')
 
 

--- a/src/eddn/Gateway.py
+++ b/src/eddn/Gateway.py
@@ -184,7 +184,7 @@ def parse_and_error_handle(data):
                     '<<UNKNOWN>>',
                     '<<UNKNOWN>>',
                     get_remote_address(),
-                    data
+                    data[:512]
             ))
 
         except Exception as e:


### PR DESCRIPTION
I noticed that the EDDN Gateway was logging some '413' responses to uploaders.  That's "Request too large".  This turns out to be due to a `bottle` default setting that limits the maximum size of requests it will handle (at least without using a temporary file, and I suspect it doesn't do that without being told to).

Closes #158 