### PR TITLE
docs: Possible server responses, and handling them

### DIFF
--- a/schemas/README-EDDN-schemas.md
+++ b/schemas/README-EDDN-schemas.md
@@ -220,8 +220,8 @@ Every message MUST comply with the schema its `$schemaRef` value cites.
 Apart from short time windows during deployment of a new version the live 
 EDDN service should always be using
 [the schemas as present in the live branch](https://github.com/EDCD/EDDN/tree/live/schemas).
-So, be sure you're checking those and not, e.g. those in the `master` or 
-other branches.
+So, be sure you're checking the live versions and not, e.g. those in the 
+`master` or other branches.
 
 Each `message` object must have, at bare minimum:
 

--- a/schemas/README-EDDN-schemas.md
+++ b/schemas/README-EDDN-schemas.md
@@ -295,7 +295,9 @@ make a valid request" responses you might experience the following:
     3. Other python exception message, e.g. if a message appeared to be 
        gzip compressed, but a failure was experienced when attempting to 
        decompress it.  **NB: As of 2022-07-01 such messages won't have the 
-       `FAIL: ` prefix.**
+       `FAIL: ` prefix.**  See
+       [#161 - Gateway: Improve reporting of 'misc' errors ](https://github.com/EDCD/EDDN/issues/161)
+       for any progress/resolution on this.
 
 2. `426` - `Upgrade Required` - You sent a message with an outdated 
    `$schemaRef` value.  This could be either an old, deprecated version of 

--- a/schemas/README-EDDN-schemas.md
+++ b/schemas/README-EDDN-schemas.md
@@ -231,6 +231,13 @@ Each `message` object must have, at bare minimum:
    doing this properly. Do not claim 'Z' whilst actually using a local time
    that is offset from UTC.
    
+   If you are only utilising Journal-sourced data then simply using the 
+   value from there should be sufficient as the PC game client is meant to 
+   always be correctly citing UTC for this.  Indeed it has been observed, 
+   in the Odyssey 4.0.0.1002 client, that with the Windows clock behind UTC 
+   by 21 seconds both the in-game UI clock *and* the Journal event 
+   timestamps are still properly UTC to the nearest second.
+
    Listeners MAY make decisions on accepting data based on this time stamp,
    i.e. "too old".
 2. At least one other key/value pair representing the data. In general there 


### PR DESCRIPTION
The possible responses to an `/upload/` request had never been documented.  This should allow senders to better ensure they properly handle such.