### PR TITLE
Support `--loglevel <level>` CL arg in all entry point scripts

### DIFF
--- a/src/eddn/Gateway.py
+++ b/src/eddn/Gateway.py
@@ -4,6 +4,7 @@
 Contains the necessary ZeroMQ socket and a helper function to publish
 market data to the Announcer daemons.
 """
+import argparse
 import gevent
 import hashlib
 import logging
@@ -49,6 +50,27 @@ validator = Validator()
 from eddn.core.StatsCollector import StatsCollector
 statsCollector = StatsCollector()
 statsCollector.start()
+
+
+def parse_cl_args():
+    parser = argparse.ArgumentParser(
+        prog='Gateway',
+        description='EDDN Gateway server',
+    )
+
+    parser.add_argument(
+        '--loglevel',
+        help='Logging level to output at',
+    )
+
+    parser.add_argument(
+        '-c', '--config',
+        metavar='config filename',
+        nargs='?',
+        default=None,
+    )
+
+    return parser.parse_args()
 
 
 def extract_message_details(parsed_message):
@@ -342,7 +364,12 @@ class EnableCors(object):
 
 
 def main():
-    loadConfig()
+
+    cl_args = parse_cl_args()
+    if cl_args.loglevel:
+        logger.setLevel(cl_args.loglevel)
+
+    loadConfig(cl_args)
     configure()
 
     app.install(EnableCors())

--- a/src/eddn/Monitor.py
+++ b/src/eddn/Monitor.py
@@ -4,6 +4,7 @@
 Monitor sit below gateways, or another relay, and simply parse what it receives over SUB.
 """
 from threading import Thread
+import argparse
 import zlib
 import gevent
 import simplejson
@@ -26,6 +27,26 @@ if Settings.RELAY_DUPLICATE_MAX_MINUTES:
     duplicateMessages = DuplicateMessages()
     duplicateMessages.start()
 
+
+def parse_cl_args():
+    parser = argparse.ArgumentParser(
+        prog='Gateway',
+        description='EDDN Gateway server',
+    )
+
+    parser.add_argument(
+        '--loglevel',
+        help='CURRENTLY NO EFFECT - Logging level to output at',
+    )
+
+    parser.add_argument(
+        '-c', '--config',
+        metavar='config filename',
+        nargs='?',
+        default=None,
+    )
+
+    return parser.parse_args()
 
 def date(__format):
     d = datetime.datetime.utcnow()
@@ -237,7 +258,9 @@ class EnableCors(object):
         return _enable_cors
 
 def main():
-    loadConfig()
+    cl_args = parse_cl_args()
+    loadConfig(cl_args)
+
     m = Monitor()
     m.start()
     app.install(EnableCors())

--- a/src/eddn/conf/Settings.py
+++ b/src/eddn/conf/Settings.py
@@ -1,6 +1,5 @@
 # coding: utf8
 
-import argparse
 import simplejson
 from eddn.conf.Version import __version__ as version
 

--- a/src/eddn/conf/Settings.py
+++ b/src/eddn/conf/Settings.py
@@ -134,15 +134,14 @@ class _Settings(object):
 Settings = _Settings()
 
 
-def loadConfig():
-    '''
-    Loads in a settings file specified on the commandline if one has been specified.
+def loadConfig(cl_args):
+    """
+    Load in a commandline-specified settings file, if applicable.
+
     A convenience method if you don't need other things specified as commandline
     options. Otherwise, point the filename to Settings.loadFrom().
-    '''
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--config", nargs="?", default=None)
-    args = parser.parse_args()
 
-    if args.config:
-        Settings.loadFrom(args.config)
+    :param cl_args: An `argparse.parse_args()` return.
+    """
+    if cl_args.config:
+        Settings.loadFrom(cl_args.config)


### PR DESCRIPTION
We might have a need to temporarily enable DEBUG level logging now and then, and don't want to have to edit code to do so.  That way lies the possibility of forgetting to edit it back, or a re-deploy accidentally undoing the change before we want to.