### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/contrib/monitor/schemas.html
+++ b/contrib/monitor/schemas.html
@@ -241,7 +241,7 @@
                     // Loop results
                     $.each(schemasCount, function(schema, hits){
                         // IF TEST CONTINUE
-                        if(schema.substr(schema.length - 4) == 'test')
+                        if(schema.slice(-4) == 'test')
                             return;
 
                         var slug = makeSlug(schema);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.