### PR TITLE
schemas: journal: Implement header->gameversion & -> gamebuild

### DIFF
--- a/docs/Developers.md
+++ b/docs/Developers.md
@@ -285,7 +285,7 @@ PC-local files for these events):
     { "timestamp":"2022-09-27T11:28:53Z", "event":"LoadGame", "FID":"<elided>", "Commander":"<elided>", "Horizons":true, ...
     ```
 
-- PC 'base' Client, game version `i3.8.0.407`, no `Odyssey` key was
+- PC 'base' Client, game version `3.8.0.407`, no `Odyssey` key was
   present:
     ```json
     { "timestamp":"2022-09-27T11:31:32Z", "event":"LoadGame", "FID":"<elided>", "Commander":"<elided>", "Horizons":false, ...

--- a/docs/Developers.md
+++ b/docs/Developers.md
@@ -175,6 +175,8 @@ For example, a shipyard message, version 2, might look like:
   "$schemaRef": "https://eddn.edcd.io/schemas/shipyard/2",
   "header": {
     "uploaderID": "Bill",
+    "gameversion": "4.0.0.1451", 
+    "gamebuild": "r286916/r0 ",
     "softwareName": "My excellent app",
     "softwareVersion": "0.0.1"
   },
@@ -183,7 +185,8 @@ For example, a shipyard message, version 2, might look like:
     "stationName": "Samson",
     "marketId": 128023552,
     "horizons": true,
-    "timestamp": "2019-01-08T06:39:43Z",
+    "odyssey": true,  
+    "timestamp": "2022-09-27T06:39:43Z",
     "ships": [
       "anaconda",
       "dolphin",
@@ -199,6 +202,57 @@ For example, a shipyard message, version 2, might look like:
   }
 }
 ```
+
+---
+
+### Contents of `header`
+You **MUST** send the `header` component of the message.
+
+#### uploaderID
+The EDDN Relay will obfuscate the `uploaderID` value to prevent long-term
+tracking of individual players.  Please **DO** send a sensible
+`uploaderID` value, preferably simply the relevant in-game Commander name.
+
+#### softwareName
+You **MUST** set a unique, and self-consistent, value of `softwareName` so
+that you can be easily identified should any issues be found with the messages
+you send.
+
+#### softwareVersion
+You **MUST** set a pertinent value for `softwareVersion`.  We would recommend
+using [Semantic Versionining](https://semver.org/#semantic-versioning-specification-semver)
+in your project.
+
+Listeners MAY make decisions on whether to accept data, or to treat it
+differently, based on this.  As such you **MUST** increment your version
+number if you make any changes to the content of messages your software sends
+to EDDN.
+
+#### `gameversions` and `gamebuild`
+To ensure that Listeners can make decisions on how to handle data based on
+the client and feature set it came from there are two mandatory fields in
+the headers of EDDN messages.
+
+The `gameversion` value **MUST** come from the field of that name in either
+`Fileheader` or `LoadGame` as outlined below.
+
+The `gamebuild` value **MUST** come from the value of the `build` field in
+either `Fileheader` or `LoadGame` as outlined below.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If the field is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have the field, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set the value to
+     `"CAPI"`.
+3. If you are sourcing data from other CAPI endpoints, i.e. for commodity,
+  shipyard or outfitting messages, then simply set the values to `"CAPI"`.
+
+---
 
 ### Contents of `message`
 Every message MUST comply with the Schema its `$schemaRef` value cites.  Each

--- a/docs/Developers.md
+++ b/docs/Developers.md
@@ -248,9 +248,13 @@ either `Fileheader` or `LoadGame` as outlined below.
      use its value.
    3. If `LoadGame` does not have the field, as with 3.8 Horizons
      clients (up to at least `3.8.0.407`), you **MUST** set the value to
-     `"CAPI"`.
+     `"CAPI-journal"`.
 3. If you are sourcing data from other CAPI endpoints, i.e. for commodity,
-  shipyard or outfitting messages, then simply set the values to `"CAPI"`.
+  shipyard or outfitting messages, then simply set the values appropriately as
+  per the CAPI endpoint the data came from:
+   1. If it's a commodity message then use `"CAPI-market"`.
+   2. If it's a shipyard message then use `"CAPI-shipyard"`.
+   3. If it's an oufitting message then also use `"CAPI-shipyard"`.
 
 ---
 

--- a/docs/Developers.md
+++ b/docs/Developers.md
@@ -231,13 +231,16 @@ to EDDN.
 #### `gameversions` and `gamebuild`
 To ensure that Listeners can make decisions on how to handle data based on
 the client and feature set it came from there are two mandatory fields in
-the headers of EDDN messages.
+the headers of EDDN messages.  NB: Initially the *schemas* do not actually
+make these mandatory, **but all Senders should make every effort to include
+them ASAP**.
 
-The `gameversion` value **MUST** come from the field of that name in either
-`Fileheader` or `LoadGame` as outlined below.
+Where present in the data source the `gameversion` value **MUST** come from
+the field of that name in the data source, i.e. from either `Fileheader` or
+`LoadGame` as outlined below.
 
-The `gamebuild` value **MUST** come from the value of the `build` field in
-either `Fileheader` or `LoadGame` as outlined below.
+For `gamebuild` you **MUST** use the value of the `build` field in the data
+source.
 
 1. If you are using Journal files directly then you **MUST** use the value
   from the`Fileheader` event.
@@ -247,14 +250,22 @@ either `Fileheader` or `LoadGame` as outlined below.
    2. If the field is present in the `LoadGame` event, as in 4.0 clients,
      use its value.
    3. If `LoadGame` does not have the field, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set the value to
-     `"CAPI-journal"`.
+     clients (up to at least `3.8.0.407`), you **SHOULD** set the value to
+     `"CAPI-journal"`. If, for reasons of code architecture, you are unable to
+     determine that data was CAPI-sourced then you MAY set it to `""` instead.
 3. If you are sourcing data from other CAPI endpoints, i.e. for commodity,
-  shipyard or outfitting messages, then simply set the values appropriately as
-  per the CAPI endpoint the data came from:
-   1. If it's a commodity message then use `"CAPI-market"`.
-   2. If it's a shipyard message then use `"CAPI-shipyard"`.
-   3. If it's an oufitting message then also use `"CAPI-shipyard"`.
+  shipyard or outfitting messages, then you **SHOULD** set the values
+  appropriately as per the CAPI endpoint the data came from:
+   1. If it's a commodity message, then use `"CAPI-market"`.
+   2. If it's a shipyard message, then use `"CAPI-shipyard"`.
+   3. If it's an oufitting message, then also use `"CAPI-shipyard"`.
+
+   Again, if your code architecture doesn't allow for signalling that the data
+  source was CAPI, then you MAY set it to `""` instead.
+
+For emphasis, **if you cannot set a data-source value, or an appropriate
+`"CAPI-..."` value then you **MUST** still send the field with an empty string
+value.
 
 ---
 

--- a/schemas/approachsettlement-README.md
+++ b/schemas/approachsettlement-README.md
@@ -58,33 +58,9 @@ Examples:
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### StarSystem
 

--- a/schemas/approachsettlement-README.md
+++ b/schemas/approachsettlement-README.md
@@ -58,6 +58,34 @@ Examples:
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 #### StarSystem
 
 You MUST add a StarSystem key/value pair representing the name of the system

--- a/schemas/approachsettlement-v1.0.json
+++ b/schemas/approachsettlement-v1.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/approachsettlement-v1.0.json
+++ b/schemas/approachsettlement-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/codexentry-README.md
+++ b/schemas/codexentry-README.md
@@ -23,6 +23,34 @@ The primary data source for this schema is the ED Journal event `CodexEntry`.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 #### StarPos
 You MUST add a `StarPos` array containing the system co-ordinates from the
 last `FSDJump`, `CarrierJump`, or `Location` event.

--- a/schemas/codexentry-README.md
+++ b/schemas/codexentry-README.md
@@ -23,33 +23,9 @@ The primary data source for this schema is the ED Journal event `CodexEntry`.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### StarPos
 You MUST add a `StarPos` array containing the system co-ordinates from the

--- a/schemas/codexentry-v1.0.json
+++ b/schemas/codexentry-v1.0.json
@@ -19,12 +19,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/codexentry-v1.0.json
+++ b/schemas/codexentry-v1.0.json
@@ -17,6 +17,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/commodity-README.md
+++ b/schemas/commodity-README.md
@@ -60,6 +60,34 @@ Remove not only the `Category_Localised` key:values, but also the
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 ### Using CAPI data
 It is *not* recommended to use CAPI data as the source as it's fraught with 
 additional issues.  EDMarketConnector does so in order to facilitate 

--- a/schemas/commodity-README.md
+++ b/schemas/commodity-README.md
@@ -60,33 +60,9 @@ Remove not only the `Category_Localised` key:values, but also the
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 ### Using CAPI data
 It is *not* recommended to use CAPI data as the source as it's fraught with 

--- a/schemas/commodity-v3.0.json
+++ b/schemas/commodity-v3.0.json
@@ -18,13 +18,11 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
-                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                    "description"   : "Fileheader->gameversion, else LoadGame->gameversion, else 'CAPI-market', else ''."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
-                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                    "description"   : "Fileheader->build, else LoadGame->build, else 'CAPI-market', else ''."
                 },
                 "softwareName": {
                     "type"          : "string"

--- a/schemas/commodity-v3.0.json
+++ b/schemas/commodity-v3.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/fcmaterials_capi-README.md
+++ b/schemas/fcmaterials_capi-README.md
@@ -57,6 +57,10 @@ You **MUST NOT** set them otherwise, as e.g. the player could be active in
 the game on another computer, using a different game mode and the CAPI data
 will be for that game mode.
 
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
+
 ## Listeners
 The advice above for [Senders](#senders), combined with the actual Schema file
 *should* provide all the information you need to process these events.

--- a/schemas/fcmaterials_capi-v1.0.json
+++ b/schemas/fcmaterials_capi-v1.0.json
@@ -16,6 +16,14 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "description"   : "Value of 'CAPI-market' if possible, else empty string."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "description"   : "Value of 'CAPI-market' if possible, else empty string."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/fcmaterials_journal-README.md
+++ b/schemas/fcmaterials_journal-README.md
@@ -33,6 +33,34 @@ of any augmentations, as noted below.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 ## Listeners
 The advice above for [Senders](#senders), combined with the actual Schema file
 *should* provide all the information you need to process these events.

--- a/schemas/fcmaterials_journal-README.md
+++ b/schemas/fcmaterials_journal-README.md
@@ -33,33 +33,9 @@ of any augmentations, as noted below.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 ## Listeners
 The advice above for [Senders](#senders), combined with the actual Schema file

--- a/schemas/fcmaterials_journal-v1.0.json
+++ b/schemas/fcmaterials_journal-v1.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/fcmaterials_journal-v1.0.json
+++ b/schemas/fcmaterials_journal-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/fssallbodiesfound-README.md
+++ b/schemas/fssallbodiesfound-README.md
@@ -24,33 +24,9 @@ The primary data source for this schema is the ED Journal event
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### StarPos
 You MUST add a `StarPos` array containing the system co-ordinates from the 

--- a/schemas/fssallbodiesfound-README.md
+++ b/schemas/fssallbodiesfound-README.md
@@ -24,6 +24,34 @@ The primary data source for this schema is the ED Journal event
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 #### StarPos
 You MUST add a `StarPos` array containing the system co-ordinates from the 
 last `FSDJump`, `CarrierJump`, or `Location` event.

--- a/schemas/fssallbodiesfound-v1.0.json
+++ b/schemas/fssallbodiesfound-v1.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/fssallbodiesfound-v1.0.json
+++ b/schemas/fssallbodiesfound-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/fssbodysignals-README.md
+++ b/schemas/fssbodysignals-README.md
@@ -24,6 +24,34 @@ The primary data source for this schema is the ED Journal event
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 #### StarSystem
 You MUST add a `StarSystem` string containing the name of the system from the 
 last `FSDJump`, `CarrierJump`, or `Location` event.

--- a/schemas/fssbodysignals-README.md
+++ b/schemas/fssbodysignals-README.md
@@ -24,33 +24,9 @@ The primary data source for this schema is the ED Journal event
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### StarSystem
 You MUST add a `StarSystem` string containing the name of the system from the 

--- a/schemas/fssbodysignals-v1.0.json
+++ b/schemas/fssbodysignals-v1.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/fssbodysignals-v1.0.json
+++ b/schemas/fssbodysignals-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/fssdiscoveryscan-README.md
+++ b/schemas/fssdiscoveryscan-README.md
@@ -24,33 +24,9 @@ The primary data source for this schema is the ED Journal event
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### StarPos
 You MUST add a `StarPos` array containing the system co-ordinates from the 

--- a/schemas/fssdiscoveryscan-README.md
+++ b/schemas/fssdiscoveryscan-README.md
@@ -24,6 +24,34 @@ The primary data source for this schema is the ED Journal event
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 #### StarPos
 You MUST add a `StarPos` array containing the system co-ordinates from the 
 last `FSDJump`, `CarrierJump`, or `Location` event.

--- a/schemas/fssdiscoveryscan-v1.0.json
+++ b/schemas/fssdiscoveryscan-v1.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/fssdiscoveryscan-v1.0.json
+++ b/schemas/fssdiscoveryscan-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/fsssignaldiscovered-README.md
+++ b/schemas/fsssignaldiscovered-README.md
@@ -87,6 +87,34 @@ You SHOULD add this key/value pair, using the value from the `LoadGame` event.
 #### odyssey flag
 You SHOULD add this key/value pair, using the value from the `LoadGame` event.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 #### StarSystem
 You **MUST** add a `StarSystem` string containing the system name from the last
 tracked location.  You **MUST** cross-check each `FSSSignalDiscovered`

--- a/schemas/fsssignaldiscovered-README.md
+++ b/schemas/fsssignaldiscovered-README.md
@@ -87,33 +87,9 @@ You SHOULD add this key/value pair, using the value from the `LoadGame` event.
 #### odyssey flag
 You SHOULD add this key/value pair, using the value from the `LoadGame` event.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### StarSystem
 You **MUST** add a `StarSystem` string containing the system name from the last

--- a/schemas/fsssignaldiscovered-v1.0.json
+++ b/schemas/fsssignaldiscovered-v1.0.json
@@ -19,12 +19,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/fsssignaldiscovered-v1.0.json
+++ b/schemas/fsssignaldiscovered-v1.0.json
@@ -17,6 +17,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/journal-README.md
+++ b/schemas/journal-README.md
@@ -94,10 +94,14 @@ You **MUST** always add this field **to the header object**.
        with the value `"CAPI"`.
 
 #### horizons flag
-You SHOULD add this key/value pair, using the value from the `LoadGame` event.
+You **MUST** add this key/value pair, using the value from the `LoadGame` event.
+
+Note caveats in [docs/Developers.md](../docs/Developers.md).
 
 #### odyssey flag
-You SHOULD add this key/value pair, using the value from the `LoadGame` event.
+You **MUST** add this key/value pair, using the value from the `LoadGame` event.
+
+Note caveats in [docs/Developers.md](../docs/Developers.md).
 
 #### StarSystem
 If not already present, you MUST add a `StarSystem` string containing the

--- a/schemas/journal-README.md
+++ b/schemas/journal-README.md
@@ -65,33 +65,9 @@ The following keys+values should be removed from `Location` event data:
 - `SquadronFaction` from within the list of `Factions`.
 
 ### Augmentations
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### horizons flag
 You **MUST** add this key/value pair, using the value from the `LoadGame` event.

--- a/schemas/journal-README.md
+++ b/schemas/journal-README.md
@@ -65,6 +65,20 @@ The following keys+values should be removed from `Location` event data:
 - `SquadronFaction` from within the list of `Factions`.
 
 ### Augmentations
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 Odyssey
+     clients, use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
 #### horizons flag
 You SHOULD add this key/value pair, using the value from the `LoadGame` event.
 

--- a/schemas/journal-README.md
+++ b/schemas/journal-README.md
@@ -73,11 +73,25 @@ You **MUST** always add this field **to the header object**.
 2. If you are using the CAPI `/journal` endpoint to retrieve and process
   Journal events then:
    1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 Odyssey
-     clients, use its value.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
    3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
      clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
      with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
 
 #### horizons flag
 You SHOULD add this key/value pair, using the value from the `LoadGame` event.

--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -16,6 +16,11 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -21,6 +21,11 @@
                     "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/navbeaconscan-README.md
+++ b/schemas/navbeaconscan-README.md
@@ -24,33 +24,9 @@ The primary data source for this schema is the ED Journal event
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### StarSystem
 You MUST add a `StarSystem` key/value pair representing the name of the

--- a/schemas/navbeaconscan-README.md
+++ b/schemas/navbeaconscan-README.md
@@ -24,6 +24,34 @@ The primary data source for this schema is the ED Journal event
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 #### StarSystem
 You MUST add a `StarSystem` key/value pair representing the name of the
 system this event occurred in.  Source this from either `Location`,

--- a/schemas/navbeaconscan-v1.0.json
+++ b/schemas/navbeaconscan-v1.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/navbeaconscan-v1.0.json
+++ b/schemas/navbeaconscan-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/navroute-README.md
+++ b/schemas/navroute-README.md
@@ -31,3 +31,30 @@ separate file.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.

--- a/schemas/navroute-README.md
+++ b/schemas/navroute-README.md
@@ -31,30 +31,7 @@ separate file.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.

--- a/schemas/navroute-v1.0.json
+++ b/schemas/navroute-v1.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/navroute-v1.0.json
+++ b/schemas/navroute-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/outfitting-README.md
+++ b/schemas/outfitting-README.md
@@ -53,3 +53,31 @@ station. Namely:
 #### horizons and odyssey flags
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
+
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.

--- a/schemas/outfitting-README.md
+++ b/schemas/outfitting-README.md
@@ -54,30 +54,7 @@ station. Namely:
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.

--- a/schemas/outfitting-v2.0.json
+++ b/schemas/outfitting-v2.0.json
@@ -18,13 +18,11 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
-                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                    "description"   : "Fileheader->gameversion, else LoadGame->gameversion, else 'CAPI-shipyard', else ''."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
-                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                    "description"   : "Fileheader->build, else LoadGame->build, else 'CAPI-shipyard', else ''."
                 },
                 "softwareName": {
                     "type"          : "string"

--- a/schemas/outfitting-v2.0.json
+++ b/schemas/outfitting-v2.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/scanbarycentre-README.md
+++ b/schemas/scanbarycentre-README.md
@@ -27,6 +27,34 @@ senders SHOULD include any defined in the schema if it's in the source data.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.
+
 #### StarPos
 You MUST add a `StarPos` array containing the system co-ordinates from the
 last `FSDJump`, `CarrierJump`, or `Location` event.

--- a/schemas/scanbarycentre-README.md
+++ b/schemas/scanbarycentre-README.md
@@ -27,33 +27,9 @@ senders SHOULD include any defined in the schema if it's in the source data.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
 #### StarPos
 You MUST add a `StarPos` array containing the system co-ordinates from the

--- a/schemas/scanbarycentre-v1.0.json
+++ b/schemas/scanbarycentre-v1.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },

--- a/schemas/scanbarycentre-v1.0.json
+++ b/schemas/scanbarycentre-v1.0.json
@@ -18,12 +18,10 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "From Fileheader event if available, else LoadGame if available there."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
                     "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
                 },
                 "softwareName": {

--- a/schemas/shipyard-README.md
+++ b/schemas/shipyard-README.md
@@ -41,30 +41,7 @@ value is what the name would have been in the source Journal data.
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
 
-#### gameversion
-You **MUST** always add this field **to the header object**.
+#### gameversion and gamebuild
+You **MUST** always set these as per [the relevant section](../docs/Developers.md#gameversions-and-gamebuild)
+of the Developers' documentation.
 
-1. If you are using Journal files directly then you **MUST** use the value
-  of the `gameversion` element from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-  Journal events then:
-   1. You will not have `Fileheader` available.
-   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
-     use its value.
-   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
-     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
-     with the value `"CAPI"`.
-
-#### gamebuild
-You **MUST** always add this field **to the header object**.
-
-1. If you are using Journal files directly then you **MUST** use the value
-   of the `build` value from the`Fileheader` event.
-2. If you are using the CAPI `/journal` endpoint to retrieve and process
-   Journal events then:
-    1. You will not have `Fileheader` available.
-    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
-      its value.
-    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
-       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
-       with the value `"CAPI"`.

--- a/schemas/shipyard-README.md
+++ b/schemas/shipyard-README.md
@@ -40,3 +40,31 @@ value is what the name would have been in the source Journal data.
 #### horizons and odyssey flags
 Please read [horizons and odyssey flags](../docs/Developers.md#horizons-and-odyssey-flags)
 in the Developers' documentation.
+
+#### gameversion
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+  of the `gameversion` element from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+  Journal events then:
+   1. You will not have `Fileheader` available.
+   2. If `gameversion` is present in the `LoadGame` event, as in 4.0 clients,
+     use its value.
+   3. If `LoadGame` does not have a `gameversion` element, as with 3.8 Horizons
+     clients (up to at least `3.8.0.407`), you **MUST** set `gameversion`, but 
+     with the value `"CAPI"`.
+
+#### gamebuild
+You **MUST** always add this field **to the header object**.
+
+1. If you are using Journal files directly then you **MUST** use the value
+   of the `build` value from the`Fileheader` event.
+2. If you are using the CAPI `/journal` endpoint to retrieve and process
+   Journal events then:
+    1. You will not have `Fileheader` available.
+    2. If `build` is present in the `LoadGame` event, as in 4.0 clients, use
+      its value.
+    3. If `LoadGame` does not have a `build` element, as with 3.8 Horizons
+       clients (up to at least `3.8.0.407`), you **MUST** set `gamebuild`, but
+       with the value `"CAPI"`.

--- a/schemas/shipyard-v2.0.json
+++ b/schemas/shipyard-v2.0.json
@@ -18,13 +18,11 @@
                 },
                 "gameversion": {
                     "type"          : "string",
-                    "minLength"     : 1,
-                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                    "description"   : "Fileheader->gameversion, else LoadGame->gameversion, else 'CAPI-shipyard', else ''."
                 },
                 "gamebuild": {
                     "type"          : "string",
-                    "minLength"     : 1,
-                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                    "description"   : "Fileheader->build, else LoadGame->build, else 'CAPI-shipyard', else ''."
                 },
                 "softwareName": {
                     "type"          : "string"

--- a/schemas/shipyard-v2.0.json
+++ b/schemas/shipyard-v2.0.json
@@ -16,6 +16,16 @@
                 "uploaderID": {
                     "type"          : "string"
                 },
+                "gameversion": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "From Fileheader event if available, else LoadGame if available there."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "The `build` value from a Fileheader event if available, else LoadGame if available there."
+                },
                 "softwareName": {
                     "type"          : "string"
                 },


### PR DESCRIPTION
*NB: The details of this are still under discussion, do not take any of these changes as set in stone yet.*

Due to the 4.0 Horizons client release there is some ambiguity with EDDN messages when using the `horizons` and `odyssey` flags to determine 'where' the data came from.  As such we're going to add new **header** fields for both `gameversion` and `gamebuild` (not just `build` due to ambiguity of that in EDDN context) to allow Listeners to better make decisions on how to process data.

On first going live these fields will be **optional** so as to give Senders time to release an update, and their users to upgrade to it.

For purely local-files Journal sourced data this is an easy change.  The CAPI data source introduces several special cases.  Check the changes to `docs/Developers.md` for details.

Senders
---
Do you envision any issues with sending the specific values outlined in the documentation?

Listeners
---
Comments on how useful this might prove to be are welcome.

In particulat review the aforementioned documentation to see if receiving Journal-derived values for these fields *when the data actually comes from CAPI endpoints* might cause you issues.