### PR TITLE
schemas/fcmaterials_json: Spec of in-array items needs to be correct

### DIFF
--- a/schemas/fcmaterials_journal-v1.0.json
+++ b/schemas/fcmaterials_journal-v1.0.json
@@ -75,27 +75,30 @@
 
                 "Items": {
                     "type"          : "array",
-                    "required"      : [ "id", "Name", "Price", "Stock", "Demand" ],
-                    "properties"    : {
-                        "id" : {
-                            "type"  : "integer"
+                    "items": {
+                        "type"          : "object",
+                        "required"      : [ "id", "Name", "Price", "Stock", "Demand" ],
+                        "properties"    : {
+                            "id" : {
+                                "type"  : "integer"
+                            },
+                            "Name": {
+                                "type"      : "string",
+                                "minLength" : 1
+                            },
+                            "Price": {
+                                "type"      : "integer"
+                            },
+                            "Stock": {
+                                "type"      : "integer"
+                            },
+                            "Demand": {
+                                "type"      : "integer"
+                            }
                         },
-                        "Name": {
-                            "type"      : "string",
-                            "minLength" : 1
-                        },
-                        "Price": {
-                            "type"      : "integer"
-                        },
-                        "Stock": {
-                            "type"      : "integer"
-                        },
-                        "Demand": {
-                            "type"      : "integer"
+                        "patternProperties": {
+                            "_Localised$"       : { "$ref" : "#/definitions/disallowed" }
                         }
-                    },
-                    "patternProperties": {
-                        "_Localised$"       : { "$ref" : "#/definitions/disallowed" }
                     }
                 }
             }


### PR DESCRIPTION
python `jsonschema` raises no errors when you erroneously forget to wrap the specification of each "array" member in `"items": { ... }`.

Closes #203