### PR TITLE
"Typo" in headline

### DIFF
--- a/schemas/fssbodysignals-README.md
+++ b/schemas/fssbodysignals-README.md
@@ -1,4 +1,4 @@
-# EDDN FSSAllBodiesFound Schema
+# EDDN FSSBodySignals Schema
 
 ## Introduction
 Here we document how to take data from an ED `FSSBodySignals` Journal 


### PR DESCRIPTION
Since this is the Readme for FSSBodySignals the Headline wrongly contains FSSAllBodiesFound.