### PR TITLE
Outfitting V3 to pass new data from operations

### DIFF
--- a/schemas/outfitting-README.md
+++ b/schemas/outfitting-README.md
@@ -33,9 +33,13 @@ value is what the name would have been in the source Journal data.
 
 ### The modules/Items list
 The source data, Journal or CAPI, contains more than just the names of the
-available items.  This Schema is only concerned with the names, so the list
+available items. 
+
+Version 2 Schema is only concerned with the names, so the list
 you build will have only strings as its members, not including other information
 such as id, category, cost/BuyPrice, sku or stock.
+
+Version 3 for Operations sends all the fields given in outfitting.
 
 ### Elisions
 Remove items whose availability depends on the Cmdr's status rather than on the

--- a/schemas/outfitting-v3.0.json
+++ b/schemas/outfitting-v3.0.json
@@ -1,0 +1,101 @@
+{
+    "$schema"               : "http://json-schema.org/draft-04/schema#",
+    "id"                    : "https://eddn.edcd.io/schemas/outfitting/3#",
+    "type"                  : "object",
+    "additionalProperties"  : false,
+    "required"              : [ "$schemaRef", "header", "message" ],
+    "properties"            : {
+        "$schemaRef": {
+            "type"                  : "string"
+        },
+        "header": {
+            "type"                  : "object",
+            "additionalProperties"  : true,
+            "required"              : [ "uploaderID", "softwareName", "softwareVersion" ],
+            "properties"            : {
+                "uploaderID": {
+                    "type"          : "string"
+                },
+                "gameversion": {
+                    "type"          : "string",
+                    "description"   : "Fileheader->gameversion, else LoadGame->gameversion, else 'CAPI-shipyard', else ''."
+                },
+                "gamebuild": {
+                    "type"          : "string",
+                    "description"   : "Fileheader->build, else LoadGame->build, else 'CAPI-shipyard', else ''."
+                },
+                "softwareName": {
+                    "type"          : "string"
+                },
+                "softwareVersion": {
+                    "type"          : "string"
+                },
+                "gatewayTimestamp": {
+                    "type"          : "string",
+                    "format"        : "date-time",
+                    "description"   : "Timestamp upon receipt at the gateway. If present, this property will be overwritten by the gateway; submitters are not intended to populate this property."
+                }
+            }
+        },
+        "message": {
+            "type"                  : "object",
+            "additionalProperties"  : false,
+            "required"              : [ "systemName", "stationName", "marketId", "timestamp", "modules" ],
+            "properties"            : {
+                "systemName": {
+                    "type"      : "string",
+                    "renamed"   : "StarSystem",
+                    "minLength" : 1
+                },
+                "stationName": {
+                    "type"      : "string",
+                    "renamed"   : "StationName",
+                    "minLength" : 1
+                },                
+                "marketId": {
+                    "type"      : "integer",
+                    "renamed"   : "MarketID"
+                },
+                "horizons": {
+                    "type"      : "boolean",
+                    "description" : "Whether the sending Cmdr has a Horizons pass."
+                },
+                "odyssey": {
+                    "type"      : "boolean",
+                    "description" : "Whether the sending Cmdr has an Odyssey expansion."
+                },                 
+                "timestamp": {
+                    "type"      : "string",
+                    "format"    : "date-time"
+                },
+                "modules": {
+                    "type"          : "array",
+                    "renamed"       : "Items",
+                    "minItems"      : 1,
+                    "uniqueItems"   : true,
+                    "description"   : "Module information, only modules Hpt_ChaffLauncher_Tiny, Int_Engine_Size3_Class5_Fast, Independant_Trader_Armour_Grade1, etc. Modules that depend on the Cmdr's purchases (e.g. bobbleheads, paintjobs) or rank (e.g. decals and PowerPlay faction-specific modules) should be omitted.  If BuyMercCoinsPrice is not present in the outfitting JSON, set it to zero in the entries"
+                    "items"         : {
+                        "type"                  : "object",
+                        "required"              : [ "id", "Name", "BuyPrice", "BuyMercCoinsPrice"],
+                        "properties"            : {
+                            "id": {
+                                "type"      : "integer",
+                            },
+                            "Name": {
+                                "type"          : "string",
+                                "minLength"     : 1
+                                "pattern"       : "(^Hpt_|^hpt_|^Int_|^int_|_Armour_|_armour_)",
+                            },
+                            "BuyPrice": { 
+                                "type"      : "integer",
+                            }
+                            "BuyMercCoinsPrice": { 
+                                "type"      : "integer",
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We need a new outfitting schema. Include all the outfitting info so a listener can tell immediately that its a merccoin without having to know the ID list.